### PR TITLE
Fix: Handled responses with null content

### DIFF
--- a/Web/API/Request.cs
+++ b/Web/API/Request.cs
@@ -391,9 +391,19 @@ namespace FrApp42.Web.API
                 response = await _httpClient.SendAsync(request);
                 result.StatusCode = (int)response.StatusCode;
 
+                if (
+                    response.Content == null ||
+                    string.IsNullOrEmpty(await response.Content.ReadAsStringAsync())
+                )
+                {
+                    result.Value = default;
+
+                    return result;
+                }
+
                 if (response.IsSuccessStatusCode)
                 {
-                    string MediaType = response.Content?.Headers?.ContentType?.MediaType.ToLower();
+                    string? MediaType = response.Content?.Headers?.ContentType?.MediaType.ToLower();
                     string ContentResponse = await response.Content?.ReadAsStringAsync();
 
                     switch (true)


### PR DESCRIPTION
In some cases, some API don't respond with a body but just with a HTTP code. MS Graph have this type of responses.
